### PR TITLE
Allow for enabling comments via front matter.

### DIFF
--- a/includes/publisher.php
+++ b/includes/publisher.php
@@ -1,5 +1,9 @@
 <?php
 
+require_once(ABSPATH . 'wp-admin/includes/media.php');
+require_once(ABSPATH . 'wp-admin/includes/file.php');
+require_once(ABSPATH . 'wp-admin/includes/image.php');
+
 if( ! defined( 'ABSPATH' ) ) exit;
 
 class GIW_Publisher{

--- a/includes/publisher.php
+++ b/includes/publisher.php
@@ -135,6 +135,10 @@ class GIW_Publisher{
             $menu_order = empty( $front_matter[ 'menu_order' ] ) ? 0 : $front_matter[ 'menu_order' ];
             $taxonomy = $front_matter[ 'taxonomy' ];
             $custom_fields = $front_matter[ 'custom_fields' ];
+            $comment_status = empty( $front_matter[ 'comment_status' ] ) ? 'closed' : $front_matter[ 'comment_status' ];
+            if ($comment_status != 'open') {
+              $comment_status = 'closed';
+            }
 
             $post_date = '';
             if( !empty( $front_matter[ 'post_date' ] ) ){
@@ -153,6 +157,7 @@ class GIW_Publisher{
             $menu_order = 0;
             $taxonomy = array();
             $custom_fields = array();
+            $comment_status = 'closed';
 
             $content = '';
             $sha = '';
@@ -176,7 +181,8 @@ class GIW_Publisher{
             'post_parent' => $parent,
             'post_date' => $post_date,
             'menu_order' => $menu_order,
-            'meta_input' => $meta_input
+            'meta_input' => $meta_input,
+            'comment_status' => $comment_status
         );
 
         $new_post_id = wp_insert_post( $post_details );


### PR DESCRIPTION
A value of

comment_status: open

in the front matter will switch on comments in wordpress. Any other value will not switch it on. The values of open/closed are as per

https://developer.wordpress.org/reference/functions/wp_insert_post/
Signed-off-by: Matthias Nott <matthias.nott@sap.com>