### PR TITLE
Avoid running into errors on embedding images.

### DIFF
--- a/includes/publisher.php
+++ b/includes/publisher.php
@@ -1,5 +1,9 @@
 <?php
 
+require_once(ABSPATH . 'wp-admin/includes/media.php');
+require_once(ABSPATH . 'wp-admin/includes/file.php');
+require_once(ABSPATH . 'wp-admin/includes/image.php');
+
 if( ! defined( 'ABSPATH' ) ) exit;
 
 class GIW_Publisher{


### PR DESCRIPTION
Avoid running into errors on embedding images.

Apparently, the original code is missing one or more of these three includes.

I found this post

https://wordpress.stackexchange.com/questions/61979/how-to-add-a-media-with-php

and with it, it works well.

Signed-off-by: Matthias Nott <matthias.nott@sap.com>