### PR TITLE
Locate the WP Contents/Uploads directory.

### DIFF
--- a/includes/parsedown.php
+++ b/includes/parsedown.php
@@ -57,8 +57,8 @@ class GIW_Parsedown extends ParsedownExtra{
         $first_character = substr( $href, 0, 1 );
         $prefix = '';
 
-        if( $first_character == '.' ){
-            $prefix = '../';
+        if( 1 || $first_character == '.' ){
+            $prefix = '../wp-content/uploads/';
         }
 
         // #2 - Remove .md file extension in relative URLs


### PR DESCRIPTION
For some reason, my images would not show up on my WP installation.

This little fix hard-codes (sort of) the path to uploads.

There should be a better way of doing this.

Signed-off-by: Matthias Nott <matthias.nott@sap.com>