### PR TITLE
Fix webhook image upload for public and private repositories

### DIFF
--- a/includes/publisher.php
+++ b/includes/publisher.php
@@ -323,7 +323,11 @@ class GIW_Publisher{
             GIW_Utils::log( 'Uploading image ' . $image_slug );
             GIW_Utils::log( $image_props );
 
-            $uploaded_image_id = media_sideload_image( $image_props[ 'raw_url' ], 0, null, 'id' );
+            // We cannot use WP media_sideload_image function for images at private GitHub repo
+            // $uploaded_image_id = media_sideload_image( $image_props[ 'raw_url' ], 0, null, 'id' );
+
+            // So we use our patched version
+            $uploaded_image_id = $this->patched_media_sideload_image( $image_props, 0, null, 'id' );            
             $uploaded_image_url = wp_get_attachment_url( $uploaded_image_id );
 
             // Check if image is uploaded correctly and 
@@ -408,6 +412,113 @@ class GIW_Publisher{
 
     }
 
+    // Changed argument from $file to $image_prope props because we need them for download
+    private function patched_media_sideload_image( $image_props, $post_id = 0, $desc = null, $return_type = 'html' ) {
+        // >>> This is patched part >>>
+        $file = $image_props['raw_url'];
+        // <<< This is patched part <<< 
+
+        if ( ! empty( $file ) ) {
+    
+            $allowed_extensions = array( 'jpg', 'jpeg', 'jpe', 'png', 'gif', 'webp' );
+    
+            /**
+             * Filters the list of allowed file extensions when sideloading an image from a URL.
+             *
+             * The default allowed extensions are:
+             *
+             *  - `jpg`
+             *  - `jpeg`
+             *  - `jpe`
+             *  - `png`
+             *  - `gif`
+             *
+             * @since 5.6.0
+             *
+             * @param string[] $allowed_extensions Array of allowed file extensions.
+             * @param string   $file               The URL of the image to download.
+             */
+            $allowed_extensions = apply_filters( 'image_sideload_extensions', $allowed_extensions, $file );
+            $allowed_extensions = array_map( 'preg_quote', $allowed_extensions );
+    
+            // Set variables for storage, fix file filename for query strings.
+            preg_match( '/[^\?]+\.(' . implode( '|', $allowed_extensions ) . ')\b/i', $file, $matches );
+    
+            if ( ! $matches ) {
+                return new WP_Error( 'image_sideload_failed', __( 'Invalid image URL.' ) );
+            }
+    
+            $file_array         = array();
+            $file_array['name'] = wp_basename( $matches[0] );
+    
+
+
+            $url_path     = parse_url( $file, PHP_URL_PATH );
+            $url_filename = '';
+            if ( is_string( $url_path ) && '' !== $url_path ) {
+                $url_filename = basename( $url_path );
+            }
+        
+            $tmpfname = wp_tempnam( $url_filename );
+            if ( ! $tmpfname ) {
+                return new WP_Error( 'http_no_file', __( 'Could not create temporary file.' ) );
+            }
+
+            // >>> This is patched part >>>
+            $contents = $this->repository->get_item_content($image_props);
+            file_put_contents($tmpfname, $contents);            
+
+            // Download file to temp location.
+            $file_array['tmp_name'] = $tmpfname;
+            // <<< This is patched part <<<
+
+            /*
+            // >>> This is original 
+            // Download file to temp location.
+            $file_array['tmp_name'] = download_url( $file );            
+            // <<< This is original
+            */
+    
+            // If error storing temporarily, return the error.
+            if ( is_wp_error( $file_array['tmp_name'] ) ) {
+                return $file_array['tmp_name'];
+            }
+    
+            // Do the validation and storage stuff.
+            $id = media_handle_sideload( $file_array, $post_id, $desc );
+    
+            // If error storing permanently, unlink.
+            if ( is_wp_error( $id ) ) {
+                @unlink( $file_array['tmp_name'] );
+                return $id;
+            }
+    
+            // Store the original attachment source in meta.
+            add_post_meta( $id, '_source_url', $file );
+    
+            // If attachment ID was requested, return it.
+            if ( 'id' === $return_type ) {
+                return $id;
+            }
+    
+            $src = wp_get_attachment_url( $id );
+        }
+    
+        // Finally, check to make sure the file has been saved, then return the HTML.
+        if ( ! empty( $src ) ) {
+            if ( 'src' === $return_type ) {
+                return $src;
+            }
+    
+            $alt  = isset( $desc ) ? esc_attr( $desc ) : '';
+            $html = "<img src='$src' alt='$alt' />";
+    
+            return $html;
+        } else {
+            return new WP_Error( 'image_sideload_failed' );
+        }
+    }
+    
 }
 
 ?>

--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -69,6 +69,11 @@ class GIW_Webhook{
             return self::error( 'invalid_data', 'Invalid data', array( 'status' => 400 ) );
         }
 
+        // These are required when in webhook mode
+        require_once(ABSPATH . 'wp-admin/includes/media.php');
+        require_once(ABSPATH . 'wp-admin/includes/file.php');
+        require_once(ABSPATH . 'wp-admin/includes/image.php');
+
         $repo_full_name = $json[ 'repository' ][ 'full_name' ];
 
         $result = GIW_Publish_Handler::publish_by_repo_full_name( $repo_full_name );


### PR DESCRIPTION
This Pull Request will fix two issues:

1) For webhooks when trying to upload image the process was interrupted. That was because we were missing loading proper files from WordPress. I have added proper `require_once` at `webhook.php`

2) For private repositories it was not possible to upload images. This was because we were using `media_sideload_image` function which was not capable of downloaing from private repo. 

Fixes #20 
Fixes #14 
Fixes #9 
Fixes #8 
Closes #7 

@vaakash I don't know how is the contribution flow in this project. If I done something wrong please tell me and I will do better.