### PR TITLE
Amend README to include steps to run composer before activation

### DIFF
--- a/compose.bat
+++ b/compose.bat
@@ -1,0 +1,33 @@
+@ECHO off
+
+@ECHO ====================
+@ECHO Composer version
+@ECHO:
+@ECHO COMPOSER URL: https://getcomposer.org/download/
+@ECHO PHP URL:      https://windows.php.net/download
+@ECHO ====================
+@CALL composer -V
+
+@ECHO:
+@ECHO:
+
+@ECHO ====================
+@ECHO remove old vendor directory
+@ECHO ====================
+@CALL RD /S /Q "vendor"
+
+@ECHO:
+@ECHO:
+
+@ECHO ====================
+@ECHO run composer
+@ECHO ====================
+@CALL composer install --optimize-autoloader --no-dev
+
+@ECHO:
+@ECHO:
+
+@ECHO ====================
+@ECHO DONE
+@ECHO ====================
+PAUSE

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ It is recommended that a permalink structure is enabled in the WordPress site so
 ## Installation
 
 1. Extract the zipped file and upload the folder `git-it-write` to to `/wp-content/plugins/` directory.
+1. Run composer to generate vendor directory, e.g. with `composer install --optimize-autoloader --no-dev`
 1. Activate the plugin through the `Plugins` menu in WordPress.
 1. Open the admin page from the "Git it Write" link under the settings menu.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author URI: https://www.aakashweb.com/
 Plugin URI: https://www.aakashweb.com/wordpress-plugins/git-it-write/
 Tags: github, markdown, editor, publish, posts, wordpress, import, custom post types
 Donate link: https://www.paypal.me/vaakash/
-License: GPLv3
+License: GPLv2 or later
 Requires PHP: 5.3
 Requires at least: 4.4
 Tested up to: 6.1.1

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author URI: https://www.aakashweb.com/
 Plugin URI: https://www.aakashweb.com/wordpress-plugins/git-it-write/
 Tags: github, markdown, editor, publish, posts, wordpress, import, custom post types
 Donate link: https://www.paypal.me/vaakash/
-License: GPLv2 or later
+License: GPLv3
 Requires PHP: 5.3
 Requires at least: 4.4
 Tested up to: 6.1.1
@@ -97,6 +97,7 @@ It is recommended that a permalink structure is enabled in the WordPress site so
 ## Installation
 
 1. Extract the zipped file and upload the folder `git-it-write` to to `/wp-content/plugins/` directory.
+1. Run composer to generate vendor directory, e.g. with `composer install --optimize-autoloader --no-dev`
 1. Activate the plugin through the `Plugins` menu in WordPress.
 1. Open the admin page from the "Git it Write" link under the settings menu.
 


### PR DESCRIPTION
fixes vaakash/git-it-write#22

Also: adds a Windows batch file to run composer.