### PR TITLE
Add support for custom_fields in GitHub posts

### DIFF
--- a/includes/parsedown.php
+++ b/includes/parsedown.php
@@ -16,6 +16,7 @@ class GIW_Parsedown extends ParsedownExtra{
         'page_template' => '',
         'taxonomy' => array(),
         'custom_fields' => array(),
+        'custom_types' => array(),
         'featured_image' => '',
         'stick_post' => '',
         'skip_file' => ''

--- a/includes/publisher.php
+++ b/includes/publisher.php
@@ -145,6 +145,7 @@ class GIW_Publisher{
             $skip_file = empty( $front_matter[ 'skip_file' ] ) ? '' : $front_matter[ 'skip_file' ];
             $taxonomy = $front_matter[ 'taxonomy' ];
             $custom_fields = $front_matter[ 'custom_fields' ];
+            $custom_types = $front_matter[ 'custom_types' ];
 
             $post_date = '';
             if( !empty( $front_matter[ 'post_date' ] ) ){
@@ -176,6 +177,7 @@ class GIW_Publisher{
             $skip_file = '';
             $taxonomy = array();
             $custom_fields = array();
+            $custom_types = array();
 
             $content = '';
             $sha = '';
@@ -188,6 +190,11 @@ class GIW_Publisher{
         }
 
         $meta_input = array_merge( $custom_fields, array(
+            'sha' => $sha,
+            'github_url' => $github_url
+        ));
+
+        $meta_input = array_merge( $custom_types, array(
             'sha' => $sha,
             'github_url' => $github_url
         ));


### PR DESCRIPTION
Hi, I'm using git-it-write to push posts to a Knowledge Base plugin called "Basepress".

In order to assign the post to the right knowledge base, I need git-it-write to support "custom_types" so I can assign the name of the Knowledge base and publish posts correctly.

See wpml-config.xml of Basepress
![image](https://github.com/vaakash/git-it-write/assets/22357995/5162730c-5cab-4931-9a2a-7b686a8fbaa9)

Hope the update is easy to do